### PR TITLE
Change the API endpoint to api.met.no

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ const log = require('debug')(require('./package.json').name);
 const performYrNoApiRequest = require('./lib/api-request');
 const endpoints = require('./lib/endpoints');
 
-const HOST = 'http://api.yr.no';
+const HOST = 'http://api.met.no';
 const PATH = '/weatherapi';
 
 

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ const log = require('debug')(require('./package.json').name);
 const performYrNoApiRequest = require('./lib/api-request');
 const endpoints = require('./lib/endpoints');
 
-const HOST = 'http://api.met.no';
+const HOST = 'https://api.met.no';
 const PATH = '/weatherapi';
 
 

--- a/lib/api-request.js
+++ b/lib/api-request.js
@@ -28,7 +28,7 @@ module.exports = function performYrNoApiRequest (opts, callback) {
       return callback(
         new VError(
           err,
-          'request to yr.no encountered an error'
+          'request to met.no encountered an error'
         ),
         null
       );
@@ -39,7 +39,7 @@ module.exports = function performYrNoApiRequest (opts, callback) {
       log('received status code %s, request was a  failure', sc);
       return callback(
         new VError(
-          'yr.no API call failed. received %s status and response body %j',
+          'met.no API call failed. received %s status and response body %j',
           sc,
           res.body
         )

--- a/test/api-request.js
+++ b/test/api-request.js
@@ -44,7 +44,7 @@ describe('api-request', () => {
 
     mod(args, (err) => {
       expect(request.called).to.be.truthy();
-      expect(err.toString()).to.contain('request to yr.no encountered an error: ETIMEDOUT');
+      expect(err.toString()).to.contain('request to met.no encountered an error: ETIMEDOUT');
       done();
     });
   });
@@ -77,7 +77,7 @@ describe('api-request', () => {
     mod(args, (err) => {
       expect(request.called).to.be.truthy();
       expect(err).to.be.truthy();
-      expect(err.toString()).to.contain('yr.no API call failed. received 500 status');
+      expect(err.toString()).to.contain('met.no API call failed. received 500 status');
       expect(err.toString()).to.contain('oh noes');
       done();
     });

--- a/test/api-request.js
+++ b/test/api-request.js
@@ -14,7 +14,7 @@ describe('api-request', () => {
     xml = '<xml>test xml string</xml>';
 
     args = {
-      url: 'http://api.met.no',
+      url: 'https://api.met.no',
       qs: {
         lat: 34.37,
         lon: 5.63

--- a/test/index.js
+++ b/test/index.js
@@ -8,7 +8,7 @@ const fs = require('fs');
 
 chai.use(require('chai-truthy'));
 
-describe('yr.no-interface', function() {
+describe('met.no-interface', function() {
   let mod, request, dublin, dublinxml;
 
   beforeEach(() => {
@@ -71,7 +71,7 @@ describe('yr.no-interface', function() {
 
       const args = request.getCall(0).args[0];
 
-      expect(args.url).to.equal('http://api.yr.no/weatherapi/locationforecast/1.9');
+      expect(args.url).to.equal('http://api.met.no/weatherapi/locationforecast/1.9');
       expect(args.qs).to.equal(dublin);
       expect(args.timeout).to.equal(60000);
 
@@ -98,7 +98,7 @@ describe('yr.no-interface', function() {
 
       const args = request.getCall(0).args[0];
 
-      expect(args.url).to.equal('http://api.yr.no/weatherapi/locationforecast/1.9');
+      expect(args.url).to.equal('http://api.met.no/weatherapi/locationforecast/1.9');
       expect(args.qs).to.equal(dublin);
       expect(args.timeout).to.equal(customTimeout);
 
@@ -126,7 +126,7 @@ describe('yr.no-interface', function() {
 
       const args = request.getCall(0).args[0];
 
-      expect(args.url).to.equal('http://api.yr.no/weatherapi/locationforecast/1.9');
+      expect(args.url).to.equal('http://api.met.no/weatherapi/locationforecast/1.9');
       expect(args.qs).to.equal(dublin);
       expect(args.timeout).to.equal(customTimeout);
 

--- a/test/index.js
+++ b/test/index.js
@@ -71,7 +71,7 @@ describe('met.no-interface', function() {
 
       const args = request.getCall(0).args[0];
 
-      expect(args.url).to.equal('http://api.met.no/weatherapi/locationforecast/1.9');
+      expect(args.url).to.equal('https://api.met.no/weatherapi/locationforecast/1.9');
       expect(args.qs).to.equal(dublin);
       expect(args.timeout).to.equal(60000);
 
@@ -98,7 +98,7 @@ describe('met.no-interface', function() {
 
       const args = request.getCall(0).args[0];
 
-      expect(args.url).to.equal('http://api.met.no/weatherapi/locationforecast/1.9');
+      expect(args.url).to.equal('https://api.met.no/weatherapi/locationforecast/1.9');
       expect(args.qs).to.equal(dublin);
       expect(args.timeout).to.equal(customTimeout);
 
@@ -126,7 +126,7 @@ describe('met.no-interface', function() {
 
       const args = request.getCall(0).args[0];
 
-      expect(args.url).to.equal('http://api.met.no/weatherapi/locationforecast/1.9');
+      expect(args.url).to.equal('https://api.met.no/weatherapi/locationforecast/1.9');
       expect(args.qs).to.equal(dublin);
       expect(args.timeout).to.equal(customTimeout);
 


### PR DESCRIPTION
As per the news on https://api.met.no/ , the api.yr.no endpoint has been deprecated for years and will be removed soon.

For completeness, the yr.no-forecast package should also be bumped have a dependency on the future release of this package.
